### PR TITLE
bugfix: remove leading/trailing whitespace from the category name

### DIFF
--- a/cost_rules/util.py
+++ b/cost_rules/util.py
@@ -19,13 +19,14 @@ def parse_env_list(string):
     return string.split(",")
 
 
-def strip_special_chars(value):
+def strip_invalid_chars(value):
     """
     The name of a cost category must adhere to: ^(?! )[\p{L}\p{N}\p{Z}-_]*(?<! )$
 
     Replace any disallowed characters with '_'
+    Strip any leading or trailing whitepace
     """
-    return re.sub("[^a-zA-Z0-9 -]", "_", value)
+    return re.sub("[^a-zA-Z0-9 -]", "_", value).strip()
 
 
 def truncate_long_strings(string):
@@ -40,4 +41,4 @@ def safe_category_name(name):
     """
     Wrap utility functions needed for category names
     """
-    return strip_special_chars(truncate_long_strings(name))
+    return strip_invalid_chars(truncate_long_strings(name))

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -10,14 +10,14 @@ def test_parse_env_list():
     assert parsed_tag_list == expected_tag_list
 
 
-def test_strip_special_chars():
+def test_strip_invalid_chars():
     """Test removing unsafe characters from cost category names"""
 
-    unsafe_name = "foo & -bar"
+    unsafe_name = " foo & -bar "
 
     expected_safe_name = "foo _ -bar"
 
-    parsed_safe_name = cost_rules.util.strip_special_chars(unsafe_name)
+    parsed_safe_name = cost_rules.util.strip_invalid_chars(unsafe_name)
     assert parsed_safe_name == expected_safe_name
 
 


### PR DESCRIPTION
The regex for allowed category names does not allow leading or trailing whitespace. Strip whitespace from the category name after truncation to remove any trailing whitespace.